### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Typograf
 [![Build Status](https://travis-ci.org/Samael500/typograf.svg?branch=master)](https://travis-ci.org/Samael500/typograf)
-[![Latest Version](https://pypip.in/version/typograf/badge.svg)](https://pypi.python.org/pypi/typograf/)
+[![Latest Version](https://img.shields.io/pypi/v/typograf.svg)](https://pypi.python.org/pypi/typograf/)
 
 client for artlebedev typograf webservice
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20typograf))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `typograf`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.